### PR TITLE
feat(load): allow adapter to accept credentials via composed plugin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   push:
-    branches: '*'
+    branches: '**'
     tags-ignore: '*'
 
 jobs:

--- a/mod.js
+++ b/mod.js
@@ -1,50 +1,86 @@
-import { ApiFactory, S3 } from "./deps.js";
+import { ApiFactory, crocks, R, S3 } from "./deps.js";
 
 import createAdapter from "./adapter.js";
 import PORT_NAME from "./port_name.js";
 
+const { Either } = crocks;
+const { Left, Right, of } = Either;
+const {
+  __,
+  assoc,
+  identity,
+  mergeRight,
+  isNil,
+  reject,
+  over,
+  lensProp,
+  defaultTo,
+} = R;
+
 export default (
   bucketPrefix,
-  { awsAccessKeyId, awsSecretKey, awsRegion } = {},
-) => ({
-  id: "s3",
-  port: PORT_NAME,
-  load: () => {
-    if (!bucketPrefix) {
-      throw new Error("Unique bucket prefix is required");
-    }
-    const args = {};
-    if (awsAccessKeyId && awsSecretKey) {
-      awsRegion = awsRegion || "us-east-1";
-      console.debug(
-        "hyper-adapter-s3: Using credentials provided through args...",
-      );
-      args.credentials = {
-        awsSecretKey,
+  { awsAccessKeyId, awsSecretKey, region } = {},
+) => {
+  const setPrefixOn = (obj) => assoc("prefix", __, obj); // expects object
+  const setAwsCreds = (env) =>
+    mergeRight(
+      env,
+      reject(isNil, {
         awsAccessKeyId,
-        region: awsRegion,
-      };
-    } else {
-      console.debug(
-        "hyper-adapter-s3: All required credentials not provided. Will attempt to pull from environment...",
-      );
-    }
+        awsSecretKey,
+        region,
+      }),
+    );
+  const setAwsRegion = (env) =>
+    mergeRight(
+      { region: "us-east-1" },
+      env,
+    );
+  const createFactory = (env) =>
+    over(
+      lensProp("factory"),
+      () =>
+        (env.awsAccessKeyId && env.awsSecretKey && env.region)
+          ? new ApiFactory({ credentials: env })
+          : /**
+           * ApiFactory attempts to pull credentials from multiple environment places
+           * If not provided via constructor
+           * See https://github.com/cloudydeno/deno-aws_api/blob/2b8605516802c1b790a2b112c03b790feb3bf58f/lib/client/credentials.ts#L50
+           */
+            new ApiFactory(),
+      env,
+    );
+  const setAws = (env) =>
+    over(
+      lensProp("aws"),
+      () => ({ factory: env.factory, s3: new S3(env.factory) }),
+      env,
+    );
 
-    /**
-     * ApiFactory attempts to pull credentials from multiple environment places
-     * If not provided via constructor
-     * See https://github.com/cloudydeno/deno-aws_api/blob/2b8605516802c1b790a2b112c03b790feb3bf58f/lib/client/credentials.ts#L50
-     */
-    // TODO: Tyler. Use `await factory.ensureCredentialsAvailable();` when load() can return a Promise
-    const factory = new ApiFactory(args);
-    const s3 = new S3(factory);
+  return Object.freeze({
+    id: "s3",
+    port: PORT_NAME,
+    load: (prevLoad) =>
+      of(prevLoad) // credentials can be received from a composed plugin
+        .map(defaultTo({}))
+        .map(setAwsCreds)
+        .map(setAwsRegion)
+        .chain((env) =>
+          notIsNil(bucketPrefix)
+            .map(setPrefixOn(env))
+        )
+        .map(createFactory)
+        .map(setAws)
+        .either(
+          (e) => console.log("Error: In Load Method", e.message),
+          identity,
+        ),
+    link: ({ prefix, aws }) => (_) => createAdapter(prefix, aws),
+  });
+};
 
-    return {
-      aws: {
-        s3,
-        factory,
-      },
-    };
-  },
-  link: ({ aws }) => (_) => createAdapter(bucketPrefix, aws),
-});
+function notIsNil(s) {
+  return isNil(s)
+    ? Left({ message: "S3 Prefix Name: can not be null or undefined!" })
+    : Right(s);
+}


### PR DESCRIPTION
This PR makes it so that the adapter's `load` function can accept credentials passed to it.

The use case is I need to fetch the aws credentials from a server before passing them into the adapter (see [this post on fetching credentials for the IAM Task Role in an ECS container](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html). With https://github.com/hyper63/hyper/pull/274 merged, load functions can return a `Promise`. With the existing composition in place for `load`, this allows composing a "credentials" plugin on top of this adapter to asynchronously fetch the credentials while keeping the `hyper-config.js` just a POJO.

Also cleaned up the style a bit to match the more functional approach the sqs adapter uses.

BREAKING CHANGE: changes `awsRegion` -> `region` to match the sqs adapter, and make handling the data a little easier.

Usage could look like:
```javascript
    {
      port: "storage",
      plugins: [
        {
          load: async () => {
            const AWS_CREDS = await fetch('credentials.endpoint').then(res => res.json())

            return {
              awsAccessKey: AWS_CREDS.AccessKeyId,
              awsSecretKey: AWS_CREDS.SecretAccessKey,
              region: AWS_REGION,
            }
          }
        },
        s3("HYPER_CLOUD"),
      ],
    }
```